### PR TITLE
Replaced xenko logo with stride logo in og image

### DIFF
--- a/images/og/ogp.jpg
+++ b/images/og/ogp.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c4baed82fd4fe34c7074f58babf4b8f62844f1e78b9db6631fc571e4520d509
-size 584969
+oid sha256:ef3bacd5305e02f0c0d18cb4648a7c52b890d05eae9344fcb0fa51488259a4e5
+size 535085


### PR DESCRIPTION
This image is used in the embedded site summary in for example facebook or discord