### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ excerpt: Stride is an open-source MIT C# game engine designed for the future of 
                         <div class="col-md-5 col-md-pull-7 principle-block">
                             <h4><span>Accelerated development</span></h4>
 							<ul>
-                            <li><strong>C# 8.0 scripting</strong></li>
+                            <li><strong>C# 9.0 scripting</strong></li>
 							<li><strong>Built-in game templates</strong></li>
 							<li><strong>Full asset creation toolchain</strong></li>
 							<li><strong>Flexible and customizable rendering pipeline</strong></li>


### PR DESCRIPTION
C# version updated from 8.0 to 9.0. This way, it is not going to confuse community. If Stride3D is supporting .NET 5 most likely it must also support C# 9.0.