### PR TITLE
Content improvements

### DIFF
--- a/community.html
+++ b/community.html
@@ -14,12 +14,12 @@ banner:
     <div class="col-md-4">
         <div class="card h-100">
             <div class="card-body">
-                <h4 class="card-title"><i class="fa-brands fa-discord text-decoration-none"></i> Discord</h4>
+                <h4 class="card-title"><i class="fa-brands fa-discord text-decoration-none"></i> Join us on Discord</h4>
                 <p>
                     Join our Discord community to engage with Stride users and developers, share your experiences, and seek advice on various topics.
                 </p>
                 <p>
-                    <a href="{{ site.links.discord-url }}" class="stretched-link" target="_blank" rel="noopener">Join Discord</a>
+                    <a href="{{ site.links.discord-url }}" class="stretched-link" target="_blank" rel="noopener">Join the Conversation on Discord</a>
                 </p>
             </div>
         </div>
@@ -27,12 +27,12 @@ banner:
     <div class="col-md-4">
         <div class="card h-100">
             <div class="card-body">
-                <h4 class="card-title"><i class="fa-solid fa-heart text-decoration-none"></i> Sponsor</h4>
+                <h4 class="card-title"><i class="fa-solid fa-heart text-decoration-none"></i> Become a Stride Sponsor</h4>
                 <p>
                     Support the Stride project by donating to help cover server costs, fund development efforts, and reward the dedicated team working behind the scenes.
                 </p>
                 <p>
-                    <a href="/sponsor/" class="stretched-link">Become a Sponsor</a>
+                    <a href="/sponsor/" class="stretched-link">Support Stride by Becoming a Sponsor</a>
                 </p>
             </div>
         </div>
@@ -40,10 +40,10 @@ banner:
     <div class="col-md-4">
         <div class="card h-100">
             <div class="card-body">
-                <h4 class="card-title"><i class="fa-brands fa-github text-decoration-none"></i> GitHub</h4>
+                <h4 class="card-title"><i class="fa-brands fa-github text-decoration-none"></i> Collaborate on GitHub</h4>
                 <p>Collaborate on the Stride project with fellow developers, contribute your unique skills, and share your ideas to enhance the platform's capabilities.</p>
                 <p>
-                    <a href="{{ site.links.github-stride-url }}" target="_blank" rel="noopener" class="stretched-link">Collaborate</a>
+                    <a href="{{ site.links.github-stride-url }}" target="_blank" rel="noopener" class="stretched-link">Help Improve Stride on GitHub</a>
                 </p>
             </div>
         </div>

--- a/download.html
+++ b/download.html
@@ -1,6 +1,6 @@
 ---
 layout: container
-title: Download
+title: Download Stride
 permalink: /download/
 menu: download
 description: 'Download the latest version of the Stride game engine and start creating immersive games and experiences. Get system requirements, installation instructions, and access to tutorials and documentation.'
@@ -13,23 +13,28 @@ banner:
     <div class="card-body p-4">
         <div class="row">
             <div class="col-lg-7 col-md-6 rt-left">
-                <h2 class="h1 mb-3">Stride is licensed under<br /> the permissive <span class="rt-accent-color1 fw-bolder">MIT</span> license</h2>
-                <p class="lead">Free to Use. Free to Change. Free to Share. Free to Sell Your Work.</p>
+                <h2 class="h1 mb-3">Your Next Game Engine</h2>
+                <p class="lead">Stride is a powerful, open-source 2D and 3D cross-platform game engine. It's free to use, modify, and distribute under the permissive <strong>MIT</strong> license. Whether you're creating a simple mobile game or the next big console hit, Stride has the features and flexibility you need.</p>
+                <h2>Your Freedom with Stride</h2>
                 <ul class="lead">
-                    <li>You are free to use Stride, for any purpose</li>
-                    <li>You are free to distribute Stride</li>
-                    <li>You can study how Stride works and change it</li>
-                    <li>You can distribute changed versions of Stride</li>
+                    <li>Use Stride for any purpose</li>
+                    <li>Distribute Stride however you like</li>
+                    <li>Dive into Stride's workings and modify it to suit your needs</li>
+                    <li>Share or distribute your modified versions of Stride</li>
                 </ul>
-                <div class="mt-5">
-                    <a href="{{ site.links.stride-download-url }}" target="_self" class="btn btn-lg btn-stride me-2 mb-3">
-                        <i class="fa-solid fa-download"></i> Installer Download
-                    </a>
-                    <a href="{{ site.links.github-stride-url }}" class="btn btn-lg btn-outline-stride mb-3" target="_blank" rel="noopener">
-                        <i class="fa-brands fa-github text-decoration-none"></i> Source Code
-                    </a>
+                <div class="mb-2">
+                    <div>
+                        <a href="{{ site.links.stride-download-url }}" target="_self" class="btn btn-lg btn-stride me-2 mt-3">
+                            <i class="fa-solid fa-download"></i> Installer Download
+                        </a>
+                        <a href="{{ site.links.github-stride-url }}" class="btn btn-lg btn-outline-stride mt-3" target="_blank" rel="noopener">
+                            <i class="fa-brands fa-github text-decoration-none"></i> Source Code
+                        </a>
+                    </div>
+                    <div class="text-secondary mt-2 small">Note: The installer download is approximately 55 MB.</div>
                 </div>
-                <p class="mt-3 lead">Read here for information on <a href="{{ site.links.docs-requirements-url }}" target="_blank" rel="noopener">system requirements</a>. The <a href="{{ site.links.docs-release-notes-url }}" target="_blank" rel="noopener">release notes</a> cover the most recent changes in current release.</p>
+                <h2>Get Started with Stride</h2>
+                <p class="lead">Before you download, make sure to check the <a href="{{ site.links.docs-requirements-url }}" target="_blank" rel="noopener">system requirements</a> for Stride. Ready to dive in? View the most recent changes in our <a href="{{ site.links.docs-release-notes-url }}" target="_blank" rel="noopener">release notes</a>.</p>
             </div>
             <div class="col-lg-5 col-md-6 rt-center feature-block">
                 <a href="/images/features/gamestudio/overview.webp" title="The GameStudio Editor" class="feature-image-container image-popup">

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ eleventyComputed:
                     </ul>
                 </div>
                 <div class="px-4 mb-4">
-                    <a href="/features/" class="btn btn-lg btn-outline-stride me-md-2">Read more</a>
+                    <a href="/features/" class="btn btn-lg btn-outline-stride me-md-2">Discover Next-Gen Capabilities</a>
                 </div>
             </div>
         </div>
@@ -67,7 +67,7 @@ eleventyComputed:
                     </ul>
                 </div>
                 <div class="px-4 mb-4">
-                    <a href="/features/" class="btn btn-lg btn-outline-stride me-md-2">Read more</a>
+                    <a href="/features/" class="btn btn-lg btn-outline-stride me-md-2">Dive Into Accelerated Development</a>
                 </div>
             </div>
         </div>
@@ -84,7 +84,7 @@ eleventyComputed:
                     </ul>
                 </div>
                 <div class="px-4 mb-4">
-                    <a href="/community/" class="btn btn-lg btn-outline-stride me-md-2">Read more</a>
+                    <a href="/community/" class="btn btn-lg btn-outline-stride me-md-2">Join Our Community</a>
                 </div>
             </div>
         </div>
@@ -100,7 +100,7 @@ eleventyComputed:
                     </ul>
                 </div>
                 <div class="px-4 mb-4">
-                    <a href="/features" class="btn btn-lg btn-outline-stride me-md-2">Read more</a>
+                    <a href="/features" class="btn btn-lg btn-outline-stride me-md-2">Explore Cross-Platform Development</a>
                 </div>
             </div>
         </div>
@@ -118,7 +118,7 @@ eleventyComputed:
                     </ul>
                 </div>
                 <div class="px-4 mb-4">
-                    <a href="/features/#scripting" class="btn btn-lg btn-outline-stride me-md-2">Read more</a>
+                    <a href="/features/#scripting" class="btn btn-lg btn-outline-stride me-md-2">Learn About Scripting in {{ site.csharp-version }}</a>
                 </div>
             </div>
         </div>
@@ -130,9 +130,9 @@ eleventyComputed:
                 <div class="card-body p-4">
                     <h2 class="h1 mb-3">History</h2>
                     <p class="lead">Xenko was originally started by <b><a href="https://www.siliconstudio.co.jp/en/" target="_blank" rel="noopener">Silicon Studio</a></b>, a technology and services company of 300+ employees founded in 2000, dedicated to driving entertainment forward. Silicon Studio develops world-class products to help developers maximize the potential of leading-edge digital media technology.</p>
-                    <p class="lead">In 2018, Silicon Studio turned Xenko into an independent open-source community-driven project.</p>
-                    <p class="lead">In 2020, Xenko was renamed to Stride.</p>
-                    <p class="lead">In 2021 May, Stride joined .NET foundation.</p>
+                    <p class="lead">In 2018, Xenko was transformed by Silicon Studio into an independent project, driven by an open-source community.</p>
+                    <p class="lead">In 2020, the project formerly known as Xenko took on a new identity as Stride.</p>
+                    <p class="lead">Then, in May of 2021, Stride proudly became a member of the .NET Foundation.</p>
                 </div>
             </div>
         </div>

--- a/sponsor.html
+++ b/sponsor.html
@@ -14,17 +14,20 @@ banner:
         <div class="row">
             <div class="col-lg-7 col-md-6 rt-left">
                 <h1 class="mb-3">Support the Future of Stride</h1>
-                <p class="lead">Stride is a community-driven free and open source project.</p>
-                <p class="lead">A big shout out to all those who sponsor the Stride Game Engine.</p>
+                <h2>Why Sponsor Stride?</h2>
+                <p class="lead">Stride is a community-driven, free, and open-source project. We're dedicated to pushing the boundaries of game development, but we can't do it alone. That's where sponsors come in.</p>
+                <h2>The Impact of Your Sponsorship</h2>
+                <p class="lead">Sponsors play a crucial role in empowering developers and creators by supporting the tools and resources they need to bring their visions to life. Your sponsorship helps maintain and improve the quality of our game engine, enhance our documentation, provide vital resources to our community, and much more.</p>
+                <h2>Join Our Community of Sponsors</h2>
                 <p>
                     <img alt="Financial Contributors badge" src="https://opencollective.com/stride3d/tiers/badge.svg" />
                 </p>
-                <p class="my-5">
+                <p class="lead">We want to extend a big shout out to all those who already sponsor the Stride Game Engine. Your dedication and backing are what make Stride's ongoing development possible. If you're not a sponsor yet, consider joining this community of visionaries who are investing in the future of game development.</p>
+                <p class="mt-4">
                     <a href="https://opencollective.com/stride3d" target="_blank" rel="noopener">
                         <img src="https://opencollective.com/stride3d/donate/button@2x.png?color=blue" width=300 />
                     </a>
                 </p>
-                <p>Sponsors play a crucial role in empowering developers and creators by supporting the tools and resources they need to bring their visions to life. The Stride project, as an open-source platform, relies on the dedication and backing of sponsors like ours to maintain and improve the quality of our game engine, documentation, and resources.</p>
             </div>
             <div class="col-lg-5 col-md-6 rt-center feature-block">
                 <a href="/images/features/gamestudio/overview.webp" title="The GameStudio Editor" class="feature-image-container image-popup">


### PR DESCRIPTION
- fixes: #79 
- home page - Call to action buttons renamed from Read more to something more engaging
- community - titles and call to action updates
- sponsor - content improvements
- download - content improvements