### PR TITLE
feat: Improve visibility of top text on responsive views

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -139,6 +139,9 @@ a {
     .image-code-script-wrapper {
         margin: 30px 30px 10px 30px;
     }
+    .carousel .carousel-inner img {
+        height: 75vh;
+    }
 }
 
 .bg-stride-website {


### PR DESCRIPTION
I have adjusted the height of .carousel .carousel-inner img to 75vh within a @media query to enhance the visibility of the top text on responsive views. This change resolves the issue of text being hidden on smaller screens.