### PR TITLE
Mastodon link on top navbar

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -42,6 +42,7 @@
     "open-collective-url": "https://opencollective.com/stride3d",
     "stackexchange-url": "https://gamedev.stackexchange.com/questions/tagged/stride",
     "twitter-url": "https://twitter.com/stridedotnet",
+    "mastodon-url": "https://mastodon.gamedev.place/@xenko",
     "youtube-url": "https://www.youtube.com/@Stride3D"
   },
   "authors": {

--- a/_includes/_top-navigation.html
+++ b/_includes/_top-navigation.html
@@ -56,9 +56,9 @@
                     </a>
                 </li>
                 <li class="nav-item col-6 col-lg-auto">
-                    <a class="nav-link py-2 px-0 px-lg-2" href="{{ site.links.twitter-url }}" target="_blank" rel="noopener" aria-label="Twitter link" title="Twitter">
-                        <i class="fa-brands fa-twitter text-decoration-none"></i>
-                        <small class="d-lg-none">Twitter</small>
+                    <a class="nav-link py-2 px-0 px-lg-2" href="{{ site.links.mastodon-url }}" target="_blank" rel="noopener" aria-label="Mastodon link" title="Mastodon">
+                        <i class="fa-brands fa-mastodon text-decoration-none"></i>
+                        <small class="d-lg-none">Mastodon</small>
                     </a>
                 </li>
                 <li class="nav-item col-6 col-lg-auto">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -56,6 +56,9 @@
                     <a class="{{ social-class }} me-2 text-decoration-none" href="{{ site.links.twitter-url }}" target="_blank" rel="noopener" aria-label="Twitter link" title="Twitter">
                         <i class="fa-brands fa-xl fa-twitter text-decoration-none"></i>
                     </a>
+                    <a class="{{ social-class }} me-2 text-decoration-none" href="{{ site.links.mastodon-url }}" target="_blank" rel="noopener" aria-label="Mastodon link" title="Mastodon">
+                        <i class="fa-brands fa-xl fa-mastodon text-decoration-none"></i>
+                    </a>
                     <a class="{{ social-class }} me-2 text-decoration-none" href="{{ site.links.open-collective-url }}" target="_blank" rel="noopener" aria-label="Open Collective link">
                         {% include svg-icons.html type:'open-collective' size:26 style:'margin-top:-5px' %}
                     </a>


### PR DESCRIPTION
Twitter link was removed from the navbar and replaced by mastodon. Now, the twitter link is only on footbar, with mastodon link.

As said in #151