### PR TITLE
fix: Change content field to use summary instead of keywords

### DIFF
--- a/scripts/search.js
+++ b/scripts/search.js
@@ -306,7 +306,7 @@
             data.push({
                 'key': key,
                 'title': docsData[key].title,
-                'content': docsData[key].keywords,
+                'content': docsData[key].summary,
                 'source': 'docs',
             });
         }


### PR DESCRIPTION
The json data https://doc.stride3d.net/latest/en/index.json are using now `summary` instead of `keywords`.

This was causing an issue when searching for data.